### PR TITLE
Notify listeners when animation completes

### DIFF
--- a/lib/src/page_list_viewport.dart
+++ b/lib/src/page_list_viewport.dart
@@ -406,6 +406,7 @@ class PageListViewportController with ChangeNotifier {
           case AnimationStatus.dismissed:
           case AnimationStatus.completed:
             _velocity = Offset.zero;
+            notifyListeners();
             break;
           case AnimationStatus.forward:
           case AnimationStatus.reverse:


### PR DESCRIPTION
Closes https://github.com/Flutter-Bounty-Hunters/page_list_viewport/issues/27

When animating with an offset, the controller never notifies its listener when the animation is complete. This means that any listeners on the controller, who react differently based on the velocity, will never receive a signal indicating when the animation has finished.