### PR TITLE
Use microseconds instead of milliseconds to avoid discontinuities during momentum simulations

### DIFF
--- a/lib/src/page_list_viewport.dart
+++ b/lib/src/page_list_viewport.dart
@@ -505,7 +505,7 @@ class PageListViewportController extends OrientationController {
 
     // Update velocity tracking.
     if (_velocityStopwatch.elapsedMilliseconds > 0) {
-      _velocity = (newOrigin - _previousOrigin) / (_velocityStopwatch.elapsedMilliseconds / 1000);
+      _velocity = (newOrigin - _previousOrigin) / (_velocityStopwatch.elapsedMicroseconds / 1000000);
       _velocityStopwatch.reset();
       _velocityResetTimer?.cancel();
 

--- a/lib/src/page_list_viewport_gestures.dart
+++ b/lib/src/page_list_viewport_gestures.dart
@@ -274,7 +274,7 @@ class _PageListViewportGesturesState extends State<PageListViewportGestures> wit
       return;
     }
 
-    final secondsFraction = elapsedTime.inMilliseconds / 1000;
+    final secondsFraction = elapsedTime.inMicroseconds / 1000000;
     final currentVelocity = _frictionSimulation!.dx(secondsFraction);
     final originBeforeDelta = widget.controller.origin;
     final newOrigin = _frictionSimulation!.x(secondsFraction);


### PR DESCRIPTION
Closes #37 

See #37 for a complete description of the problem. In summary, it seems that the elapsed time between frames is not constant and this is resulting in the animation of the origin during the momentum simulation to appear as if it skips every few frames. This can be seen if you capture the elapsedTime as reported by the ticker and the origin for each frame of the momentum simulation:

<img width="451" alt="Screen Shot 2023-05-17 at 7 23 02 PM" src="https://github.com/Flutter-Bounty-Hunters/page_list_viewport/assets/8084674/f9bc3132-4436-4990-a4e8-89cd93fa6112">

Looking closer at how the timestamp is calculated, the elapsed duration as reported by the ticker is converted from milliseconds:
```
final secondsFraction = elapsedTime.inMilliseconds / 1000;
```

Since milliseconds is an integer, that means we only have 3 significant digits after the zero. For example, if the elapsed duration is 500ms, then in seconds that would be 0.500s. However, given that the refresh rates of the display vary between 60hz, 90hz, and 120hz, that means that we are refreshing every 0.01667s, 0.0111s, and 0.008333s respectively. Since our refresh rates require at least 5 digits of precision, by calculating the elapsed time in milliseconds, every few frames we are prone to a rounding error. These rounding errors than result in the origin to be discontinuous.

Converting the elapsed time to be measured in microseconds increases the resolution of the elapsed time such that the origin is continuous across each frame (except for when the viewport drops a frame).

Similar example to the above, except this time using microseconds:
<img width="460" alt="Screen Shot 2023-05-17 at 7 44 03 PM" src="https://github.com/Flutter-Bounty-Hunters/page_list_viewport/assets/8084674/11f6e118-85bf-41a4-b2d6-5a25bd46f22c">

As you can see, the refresh rate is constant across frames and in turn the viewports origin is translated in a continuous manner.