### PR TITLE
Changed PageListViewportController to let it be driven by a simulation, so that the controller has direct access to the same clock as the simulation, which seems necessary for us to get smooth velocity measurements (Resolves #34)

### DIFF
--- a/example/lib/main_list.dart
+++ b/example/lib/main_list.dart
@@ -1,3 +1,4 @@
+import 'package:example/momentum_verification/velocity_plotter.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:page_list_viewport/page_list_viewport.dart';
@@ -32,7 +33,7 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> with SingleTickerProviderStateMixin {
+class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   static const _pageCount = 20;
   static const _naturalPageSizeInInches = Size(8.5, 11);
 
@@ -69,32 +70,49 @@ class _MyHomePageState extends State<MyHomePage> with SingleTickerProviderStateM
   }
 
   Widget _buildViewport() {
-    return PageListViewportGestures(
-      controller: _controller,
-      lockPanAxis: true,
-      child: PageListViewport(
-        controller: _controller,
-        pageCount: _pageCount,
-        naturalPageSize: _naturalPageSizeInInches * 72 * MediaQuery.of(context).devicePixelRatio,
-        pageLayoutCacheCount: 3,
-        pagePaintCacheCount: 3,
-        builder: (BuildContext context, int pageIndex) {
-          return Stack(
-            children: [
-              Positioned.fill(
-                child: _buildPage(pageIndex),
-              ),
-              Center(
-                child: Container(
-                  padding: const EdgeInsets.all(32),
-                  color: Colors.white,
-                  child: Text("Page: $pageIndex"),
-                ),
-              )
-            ],
-          );
-        },
-      ),
+    return Stack(
+      children: [
+        PageListViewportGestures(
+          controller: _controller,
+          lockPanAxis: true,
+          child: PageListViewport(
+            controller: _controller,
+            pageCount: _pageCount,
+            naturalPageSize: _naturalPageSizeInInches * 72 * MediaQuery.of(context).devicePixelRatio,
+            pageLayoutCacheCount: 3,
+            pagePaintCacheCount: 3,
+            builder: (BuildContext context, int pageIndex) {
+              return Stack(
+                children: [
+                  Positioned.fill(
+                    child: _buildPage(pageIndex),
+                  ),
+                  Center(
+                    child: Container(
+                      padding: const EdgeInsets.all(32),
+                      color: Colors.white,
+                      child: Text("Page: $pageIndex"),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ),
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: 300,
+          child: ColoredBox(
+            color: Colors.black.withOpacity(0.5),
+            child: VelocityPlotter(
+              controller: _controller,
+              max: const Offset(6000, 6000),
+            ),
+          ),
+        )
+      ],
     );
   }
 

--- a/example/lib/main_single_page_orientation.dart
+++ b/example/lib/main_single_page_orientation.dart
@@ -31,7 +31,7 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> with SingleTickerProviderStateMixin {
+class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   late final PageListViewportController _controller;
   final _layerLink = LayerLink();
 

--- a/example/lib/momentum_verification/velocity_plotter.dart
+++ b/example/lib/momentum_verification/velocity_plotter.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:page_list_viewport/page_list_viewport.dart';
+
+class VelocityPlotter extends StatefulWidget {
+  const VelocityPlotter({
+    super.key,
+    required this.controller,
+    required this.max,
+  });
+
+  final PageListViewportController controller;
+  final Offset max;
+
+  @override
+  State<VelocityPlotter> createState() => _VelocityPlotterState();
+}
+
+class _VelocityPlotterState extends State<VelocityPlotter> {
+  final _velocityLogicalPoint = <Offset>[];
+  final _velocityVisiblePoints = <Offset>[];
+  final _accelerationLogicalPoints = <Offset>[];
+  final _accelerationVisiblePoints = <Offset>[];
+  final _sampleCount = ValueNotifier(0);
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onControllerChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant VelocityPlotter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onControllerChanged);
+      widget.controller.addListener(_onControllerChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    widget.controller.removeListener(_onControllerChanged);
+  }
+
+  Offset? _lastVelocity;
+  final _stopwatch = Stopwatch();
+
+  void _onControllerChanged() {
+    if (_stopwatch.isRunning == false) {
+      _stopwatch.start();
+    }
+    if (_stopwatch.elapsedMilliseconds == 0) {
+      // No time has passed. We don't want to divide things by zero.
+      return;
+    }
+    final velocity = widget.controller.velocity;
+    _velocityLogicalPoint.add(velocity);
+    if (_lastVelocity != null) {
+      // final acceleration = (velocity - _lastVelocity!) / (_stopwatch.elapsedMilliseconds / 1000);
+      final acceleration = widget.controller.acceleration * 100;
+      _accelerationLogicalPoints.add(acceleration);
+    }
+
+    // Increment sample count so that we cause a repaint in the CustomPainter
+    _sampleCount.value = _velocityLogicalPoint.length;
+
+    _lastVelocity = velocity;
+    _stopwatch.reset();
+  }
+
+  void _clearPlot() {
+    _velocityLogicalPoint.clear();
+    _velocityVisiblePoints.clear();
+    _accelerationLogicalPoints.clear();
+    _accelerationVisiblePoints.clear();
+    _sampleCount.value = 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: GestureDetector(
+        onDoubleTap: _clearPlot,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: CustomPaint(
+                painter: _PlotterPainter(
+                  logicalPoints: _accelerationLogicalPoints,
+                  visiblePoints: _accelerationVisiblePoints,
+                  max: widget.max,
+                  color: Colors.red.withOpacity(0.5),
+                  repaint: _sampleCount,
+                ),
+              ),
+            ),
+            Positioned.fill(
+              child: CustomPaint(
+                painter: _PlotterPainter(
+                  logicalPoints: _velocityLogicalPoint,
+                  visiblePoints: _velocityVisiblePoints,
+                  max: widget.max,
+                  color: Colors.greenAccent,
+                  repaint: _sampleCount,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PlotterPainter extends CustomPainter {
+  static const _maxSampleDisplayCount = 300;
+
+  _PlotterPainter({
+    required this.max,
+    required this.logicalPoints,
+    required this.visiblePoints,
+    required this.color,
+    super.repaint,
+  }) {
+    pointPainter.color = color;
+    linePaint
+      ..color = color
+      ..strokeWidth = 1
+      ..style = PaintingStyle.stroke;
+  }
+
+  final Offset max;
+  final List<Offset> logicalPoints;
+  final List<Offset> visiblePoints;
+  final Color color;
+
+  final pointPainter = Paint();
+  final linePaint = Paint();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    _convertLogicalPointsToPlotPoints(size);
+
+    canvas.clipRect(Offset.zero & size);
+
+    final horizontalStepSize = size.width / _maxSampleDisplayCount;
+    for (var i = 0; i < visiblePoints.length; i += 1) {
+      final plotPoint = visiblePoints[i].translate(i * horizontalStepSize, 0);
+      final previousPlotPoint = i > 0 ? visiblePoints[i - 1].translate((i - 1) * horizontalStepSize, 0) : null;
+
+      // Draw a line connecting previous and current plot point.
+      if (previousPlotPoint != null) {
+        canvas.drawLine(previousPlotPoint, plotPoint, linePaint);
+      }
+
+      // Draw the current plot point.
+      canvas.drawCircle(plotPoint, 2, pointPainter);
+    }
+  }
+
+  void _convertLogicalPointsToPlotPoints(Size size) {
+    final scaleY = size.height / (max.dy * 2);
+
+    for (var i = 0; i < logicalPoints.length; i += 1) {
+      final logicalPoint = logicalPoints[i];
+
+      final plotPoint = Offset(
+        0,
+        size.height - ((logicalPoint.dy + max.dy) * scaleY),
+      );
+
+      visiblePoints.add(plotPoint);
+    }
+
+    if (visiblePoints.length > _maxSampleDisplayCount) {
+      visiblePoints.removeRange(0, visiblePoints.length - _maxSampleDisplayCount);
+    }
+
+    logicalPoints.clear();
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return false;
+  }
+}


### PR DESCRIPTION
Changed PageListViewportController to let it be driven by a simulation, so that the controller has direct access to the same clock as the simulation, which seems necessary for us to get smooth velocity measurements (Resolves #34)

We still get a bit of choppyness in the reported acceleration (though it's much better than before)


https://github.com/Flutter-Bounty-Hunters/page_list_viewport/assets/7259036/0bd1b543-d6de-4da9-be01-219f221aa885

I see a visual jitter when the choppy velocity appears. I don't think I see a visual jitter when the curve is smooth.

I tried to profile frame times to see if jank frames were associated with the choppy velocity. Unfortunately, I discovered the Flutter's profiler is completely broken when collecting frame data.

https://github.com/flutter/flutter/issues/127276