### PR TITLE
Bugfix: scrolling equation sign

### DIFF
--- a/lib/src/page_list_viewport_gestures.dart
+++ b/lib/src/page_list_viewport_gestures.dart
@@ -334,7 +334,6 @@ class _PageListViewportGesturesState extends State<PageListViewportGestures> wit
   }
 }
 
-
 /// Definiton for gestures' translation distance and velocity categories.
 ///
 /// Distances are tiny, small, and large.
@@ -1070,6 +1069,6 @@ class FrictionAndFirstOrderDragBallisticSimulation extends Simulation {
 
   @override
   bool isDone(double time) {
-    return time < _finalTime;
+    return time > _finalTime;
   }
 }


### PR DESCRIPTION
This is a minor sign fix. To my knowledge it doesn't affect the performance of the scrolling because we do not utilize every method (including isDone) of the custom simulation, but this could potentially be malicious in further work.